### PR TITLE
Added A 1.0 Branch Alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,6 @@
             "email": "john@johnkary.net"
         }
     ],
-    "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.0"
     },
@@ -21,6 +20,11 @@
     "autoload": {
         "psr-0": {
             "JohnKary": "src/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "1.0-dev"
         }
     }
 }


### PR DESCRIPTION
Currently, people have to use `"dev-master"` to install this which is a terrible practice. With this change, they can now use `"~1.0@dev"`, or `"1.0.*@dev"`, or something similar.

Also, that minimum stability thing isn't required since composer defaults to stable.
