### PR TITLE
Add support for PHPUnit 6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/phpunit.xml
 /vendor
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: false
 
 php:
-  - 5.6
   - 7.0
   - 7.1
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,4 +20,4 @@ before_script:
   - composer require phpunit/phpunit:${PHPUNIT}
 
 script:
-  - ./vendor/bin/phpunit -c phpunit.xml.example --testsuite tests
+  - ./vendor/bin/phpunit -c phpunit.xml.example

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ cache:
 
 before_script:
   - phpenv config-rm xdebug.ini || true
-  - composer self-update
   - composer require phpunit/phpunit:${PHPUNIT}
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,7 @@ php:
   - hhvm
 
 env:
-  - PHPUNIT=4.7.*
-  - PHPUNIT=4.8.*
-  - PHPUNIT=5.0.*
-  - PHPUNIT=5.1.*
-  - PHPUNIT=5.2.*
-  - PHPUNIT=5.3.*
-  - PHPUNIT=5.4.*
-  - PHPUNIT=5.5.*
-  - PHPUNIT=5.6.*
-  - PHPUNIT=5.7.*
+  - PHPUNIT=6.0.*
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.0
   - 7.1
   - nightly
-  - hhvm
 
 env:
   - PHPUNIT=6.0.*

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "phpunit/phpunit": ">=6.0"
+        "phpunit/phpunit": "^6.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.0",
         "phpunit/phpunit": ">=4.7"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "phpunit/phpunit": ">=4.7"
+        "phpunit/phpunit": ">=6.0"
     },
     "autoload": {
         "psr-0": {

--- a/phpunit.xml.example
+++ b/phpunit.xml.example
@@ -38,7 +38,7 @@
         <whitelist>
             <directory>src</directory>
             <exclude>
-                <directory>src/*/Tests</directory>
+                <directory>src/*/*/*/Tests</directory>
             </exclude>
         </whitelist>
     </filter>

--- a/phpunit.xml.example
+++ b/phpunit.xml.example
@@ -17,9 +17,6 @@
         <testsuite name="Project Test Suite">
             <directory>src/*/*/*/Tests</directory>
         </testsuite>
-        <testsuite name="tests">
-            <directory>tests</directory>
-        </testsuite>
     </testsuites>
 
     <listeners>

--- a/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
+++ b/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
@@ -2,11 +2,18 @@
 
 namespace JohnKary\PHPUnit\Listener;
 
+use PHPUnit\Framework\AssertionFailedError;
+use PHPUnit\Framework\TestSuite;
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\Warning;
+
 /**
  * A PHPUnit TestListener that exposes your slowest running tests by outputting
  * results directly to the console.
  */
-class SpeedTrapListener implements \PHPUnit_Framework_TestListener
+class SpeedTrapListener implements TestListener
 {
     /**
      * Internal tracking for test suites.
@@ -53,92 +60,87 @@ class SpeedTrapListener implements \PHPUnit_Framework_TestListener
     /**
      * An error occurred.
      *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
+     * @param Test       $test
+     * @param \Exception $e
+     * @param float      $time
      */
-    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function addError(Test $test, \Exception $e, $time)
     {
     }
 
     /**
      * A warning occurred.
      *
-     * @param \PHPUnit_Framework_Test    $test
-     * @param \PHPUnit_Framework_Warning $e
-     * @param float                     $time
-     *
-     * @since Method available since Release 6.0.0
-     * @todo  Uncomment in time for PHPUnit 6.0.0
-     * @see   https://github.com/sebastianbergmann/phpunit/pull/1840#issuecomment-162535997
+     * @param Test    $test
+     * @param Warning $e
+     * @param float   $time
      */
-    public function addWarning(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_Warning $e, $time)
+    public function addWarning(Test $test, Warning $e, $time)
     {
     }
 
     /**
      * A failure occurred.
      *
-     * @param \PHPUnit_Framework_Test                 $test
-     * @param \PHPUnit_Framework_AssertionFailedError $e
-     * @param float                                   $time
+     * @param Test                 $test
+     * @param AssertionFailedError $e
+     * @param float                $time
      */
-    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+    public function addFailure(Test $test, AssertionFailedError $e, $time)
     {
     }
 
     /**
      * Incomplete test.
      *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
+     * @param Test       $test
+     * @param \Exception $e
+     * @param float      $time
      */
-    public function addIncompleteTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function addIncompleteTest(Test $test, \Exception $e, $time)
     {
     }
 
     /**
      * Risky test.
      *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
-     * @since  Method available since Release 4.0.0
+     * @param Test       $test
+     * @param \Exception $e
+     * @param float      $time
      */
-    public function addRiskyTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function addRiskyTest(Test $test, \Exception $e, $time)
     {
     }
 
     /**
      * Skipped test.
      *
-     * @param \PHPUnit_Framework_Test $test
-     * @param \Exception              $e
-     * @param float                   $time
+     * @param Test       $test
+     * @param \Exception $e
+     * @param float      $time
      */
-    public function addSkippedTest(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function addSkippedTest(Test $test, \Exception $e, $time)
     {
     }
 
     /**
      * A test started.
      *
-     * @param \PHPUnit_Framework_Test $test
+     * @param Test $test
      */
-    public function startTest(\PHPUnit_Framework_Test $test)
+    public function startTest(Test $test)
     {
     }
 
     /**
      * A test ended.
      *
-     * @param \PHPUnit_Framework_Test $test
-     * @param float                   $time
+     * @param Test  $test
+     * @param float $time
      */
-    public function endTest(\PHPUnit_Framework_Test $test, $time)
+    public function endTest(Test $test, $time)
     {
-        if (!$test instanceof \PHPUnit_Framework_TestCase) return;
+        if (!$test instanceof TestCase) return;
 
         $time = $this->toMilliseconds($time);
         $threshold = $this->getSlowThreshold($test);
@@ -151,9 +153,9 @@ class SpeedTrapListener implements \PHPUnit_Framework_TestListener
     /**
      * A test suite started.
      *
-     * @param \PHPUnit_Framework_TestSuite $suite
+     * @param TestSuite $suite
      */
-    public function startTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    public function startTestSuite(TestSuite $suite)
     {
         $this->suites++;
     }
@@ -161,9 +163,9 @@ class SpeedTrapListener implements \PHPUnit_Framework_TestListener
     /**
      * A test suite ended.
      *
-     * @param \PHPUnit_Framework_TestSuite $suite
+     * @param TestSuite $suite
      */
-    public function endTestSuite(\PHPUnit_Framework_TestSuite $suite)
+    public function endTestSuite(TestSuite $suite)
     {
         $this->suites--;
 
@@ -191,10 +193,10 @@ class SpeedTrapListener implements \PHPUnit_Framework_TestListener
     /**
      * Stores a test as slow.
      *
-     * @param \PHPUnit_Framework_TestCase $test
+     * @param TestCase $test
      * @param int                         $time Test execution time in milliseconds
      */
-    protected function addSlowTest(\PHPUnit_Framework_TestCase $test, $time)
+    protected function addSlowTest(TestCase $test, $time)
     {
         $label = $this->makeLabel($test);
 
@@ -225,10 +227,10 @@ class SpeedTrapListener implements \PHPUnit_Framework_TestListener
     /**
      * Label for describing a test.
      *
-     * @param \PHPUnit_Framework_TestCase $test
+     * @param TestCase $test
      * @return string
      */
-    protected function makeLabel(\PHPUnit_Framework_TestCase $test)
+    protected function makeLabel(TestCase $test)
     {
         return sprintf('%s:%s', get_class($test), $test->getName());
     }
@@ -319,10 +321,10 @@ class SpeedTrapListener implements \PHPUnit_Framework_TestListener
      * public function testLongRunningProcess() {}
      * </code>
      *
-     * @param \PHPUnit_Framework_TestCase $test
+     * @param TestCase $test
      * @return int
      */
-    protected function getSlowThreshold(\PHPUnit_Framework_TestCase $test)
+    protected function getSlowThreshold(TestCase $test)
     {
         $ann = $test->getAnnotations();
 

--- a/src/JohnKary/PHPUnit/Listener/Tests/ExceptionalTest.php
+++ b/src/JohnKary/PHPUnit/Listener/Tests/ExceptionalTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace JohnKary\PHPUnit\Listener\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class ExceptionalTest extends TestCase
+{
+    public function testExceptionCanBeThrownInTest()
+    {
+        $this->expectException('InvalidArgumentException');
+        $this->expectExceptionMessage('CODE1');
+        throw new \InvalidArgumentException('CODE1');
+    }
+
+    public function testSkippedTest()
+    {
+        $this->markTestSkipped('Skipped tests do not cause Exceptions in Listener');
+    }
+
+    public function testIncompleteTest()
+    {
+        $this->markTestIncomplete('Incomplete tests do not cause Exceptions in Listener');
+    }
+}
+ 

--- a/src/JohnKary/PHPUnit/Listener/Tests/SomeSlowTest.php
+++ b/src/JohnKary/PHPUnit/Listener/Tests/SomeSlowTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace JohnKary\PHPUnit\Listener\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class SomeSlowTest extends TestCase
+{
+    public function testFastTest()
+    {
+        $this->assertTrue(true);
+    }
+
+    public function testSlowTests()
+    {
+        $this->extendTime(300);
+
+        $this->assertTrue(true);
+    }
+
+    public function testAnotherSlowTests()
+    {
+        $this->extendTime(500);
+
+        $this->assertTrue(true);
+    }
+
+    public function testLongEndToEndTest()
+    {
+        $this->extendTime(500);
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @dataProvider provideTime
+     */
+    public function testWithDataProvider($time)
+    {
+        $this->extendTime($time);
+
+        $this->assertTrue(true);
+    }
+    public function provideTime()
+    {
+        return array(
+            'Rock' => array(800),
+            'Chalk' => array(700),
+            'Jayhawk' => array(600),
+        );
+    }
+
+    /**
+     * This test's runtime would normally be under the suite's threshold, but
+     * this annotation sets a lower threshold, causing it to be considered slow
+     * and reported on in the test output.
+     *
+     * @slowThreshold 5
+     */
+    public function testCanSetLowerSlowThreshold()
+    {
+        $this->extendTime(10);
+        $this->assertTrue(true);
+    }
+
+    /**
+     * This test's runtime would normally be over the suite's threshold, but
+     * this annotation sets a higher threshold, causing it to be not be
+     * considered slow and not reported on in the test output.
+     *
+     * @slowThreshold 50000
+     */
+    public function testCanSetHigherSlowThreshold()
+    {
+        $this->extendTime(600);
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @param int $ms Number of additional microseconds to execute code
+     */
+    private function extendTime($ms)
+    {
+        usleep($ms * 1000);
+    }
+}

--- a/tests/SlowTest.php
+++ b/tests/SlowTest.php
@@ -1,9 +1,0 @@
-<?php
-
-class SlowTest extends \PHPUnit_Framework_TestCase
-{
-    public function testListener()
-    {
-        sleep(1);
-    }
-}


### PR DESCRIPTION
`phpunit-speedtrap` master branch now supports a future 2.0 of `SpeedTrapListener`. This PR updates the listener to only support PHPUnit 6.0 and increases the minimum PHP version to 7.0.

This PR also adds more unit tests I had been using locally during development to ensure the listener functioned correctly. Long-term I would like a more robust test strategy that does not rely on visually examining the PHPUnit test runner output.

Should any other changes be made before merge? Please add your reaction to this post or comment below. Thanks! 🚀 