### PR TITLE
Add PHP 7 features

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,21 @@
+UPGRADE FROM 1.x to 2.0
+=======================
+
+### `JohnKary\PHPUnit\Listener\SpeedTrapListener` subclasses must implement scalar type hints
+
+SpeedTrapListener was upgraded to support PHP 7 scalar type hints. Any
+subclass will need to update the overridden function signature:
+
+* Declare strict types at the top of your subclass: `declare(strict_types=1);`
+* Update method signatures:
+
+| Old signature | New signature |
+| -------- | --- |
+| `protected function isSlow($time, $slowThreshold)` | `protected function isSlow(int $time, int $slowThreshold) : bool`
+| `protected function addSlowTest(TestCase $test, $time)` | `protected function addSlowTest(TestCase $test, int $time)`
+| `protected function hasSlowTests()` | `protected function hasSlowTests() : bool`
+| `protected function toMilliseconds($time)` | `protected function toMilliseconds(float $time) : int`
+| `protected function makeLabel(TestCase $test)` | `protected function makeLabel(TestCase $test) : string`
+| `protected function getReportLength()` | `protected function getReportLength() : int`
+| `protected function getHiddenCount()` | `protected function getHiddenCount() : int`
+| `protected function getSlowThreshold(TestCase $test)` | `protected function getSlowThreshold(TestCase $test) : int`

--- a/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
+++ b/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener;
 
@@ -187,7 +188,7 @@ class SpeedTrapListener implements TestListener
      * @param int $slowThreshold Test execution time at which a test should be considered slow (milliseconds)
      * @return bool
      */
-    protected function isSlow($time, $slowThreshold)
+    protected function isSlow(int $time, int $slowThreshold) : bool
     {
         return $time >= $slowThreshold;
     }
@@ -196,9 +197,9 @@ class SpeedTrapListener implements TestListener
      * Stores a test as slow.
      *
      * @param TestCase $test
-     * @param int                         $time Test execution time in milliseconds
+     * @param int      $time Test execution time in milliseconds
      */
-    protected function addSlowTest(TestCase $test, $time)
+    protected function addSlowTest(TestCase $test, int $time)
     {
         $label = $this->makeLabel($test);
 
@@ -210,7 +211,7 @@ class SpeedTrapListener implements TestListener
      *
      * @return bool
      */
-    protected function hasSlowTests()
+    protected function hasSlowTests() : bool
     {
         return !empty($this->slow);
     }
@@ -221,7 +222,7 @@ class SpeedTrapListener implements TestListener
      * @param float $time
      * @return int
      */
-    protected function toMilliseconds($time)
+    protected function toMilliseconds(float $time) : int
     {
         return (int) round($time * 1000);
     }
@@ -232,7 +233,7 @@ class SpeedTrapListener implements TestListener
      * @param TestCase $test
      * @return string
      */
-    protected function makeLabel(TestCase $test)
+    protected function makeLabel(TestCase $test) : string
     {
         return sprintf('%s:%s', get_class($test), $test->getName());
     }
@@ -242,7 +243,7 @@ class SpeedTrapListener implements TestListener
      *
      * @return int
      */
-    protected function getReportLength()
+    protected function getReportLength() : int
     {
         return min(count($this->slow), $this->reportLength);
     }
@@ -253,7 +254,7 @@ class SpeedTrapListener implements TestListener
      *
      * @return int
      */
-    protected function getHiddenCount()
+    protected function getHiddenCount() : int
     {
         $total = count($this->slow);
         $showing = $this->getReportLength();
@@ -327,10 +328,10 @@ class SpeedTrapListener implements TestListener
      * @param TestCase $test
      * @return int
      */
-    protected function getSlowThreshold(TestCase $test)
+    protected function getSlowThreshold(TestCase $test) : int
     {
         $ann = $test->getAnnotations();
 
-        return isset($ann['method']['slowThreshold'][0]) ? $ann['method']['slowThreshold'][0] : $this->slowThreshold;
+        return isset($ann['method']['slowThreshold'][0]) ? (int) $ann['method']['slowThreshold'][0] : $this->slowThreshold;
     }
 }

--- a/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
+++ b/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
@@ -308,8 +308,8 @@ class SpeedTrapListener implements TestListener
      */
     protected function loadOptions(array $options)
     {
-        $this->slowThreshold = isset($options['slowThreshold']) ? $options['slowThreshold'] : 500;
-        $this->reportLength = isset($options['reportLength']) ? $options['reportLength'] : 10;
+        $this->slowThreshold = $options['slowThreshold'] ?? 500;
+        $this->reportLength = $options['reportLength'] ?? 10;
     }
 
     /**

--- a/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
+++ b/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
@@ -183,7 +183,7 @@ class SpeedTrapListener implements TestListener
      * @param int $slowThreshold Test execution time at which a test should be considered slow (milliseconds)
      * @return bool
      */
-    protected function isSlow(int $time, int $slowThreshold) : bool
+    protected function isSlow(int $time, int $slowThreshold): bool
     {
         return $time >= $slowThreshold;
     }
@@ -206,7 +206,7 @@ class SpeedTrapListener implements TestListener
      *
      * @return bool
      */
-    protected function hasSlowTests() : bool
+    protected function hasSlowTests(): bool
     {
         return !empty($this->slow);
     }
@@ -217,7 +217,7 @@ class SpeedTrapListener implements TestListener
      * @param float $time
      * @return int
      */
-    protected function toMilliseconds(float $time) : int
+    protected function toMilliseconds(float $time): int
     {
         return (int) round($time * 1000);
     }
@@ -228,7 +228,7 @@ class SpeedTrapListener implements TestListener
      * @param TestCase $test
      * @return string
      */
-    protected function makeLabel(TestCase $test) : string
+    protected function makeLabel(TestCase $test): string
     {
         return sprintf('%s:%s', get_class($test), $test->getName());
     }
@@ -238,7 +238,7 @@ class SpeedTrapListener implements TestListener
      *
      * @return int
      */
-    protected function getReportLength() : int
+    protected function getReportLength(): int
     {
         return min(count($this->slow), $this->reportLength);
     }
@@ -249,7 +249,7 @@ class SpeedTrapListener implements TestListener
      *
      * @return int
      */
-    protected function getHiddenCount() : int
+    protected function getHiddenCount(): int
     {
         $total = count($this->slow);
         $showing = $this->getReportLength();
@@ -323,7 +323,7 @@ class SpeedTrapListener implements TestListener
      * @param TestCase $test
      * @return int
      */
-    protected function getSlowThreshold(TestCase $test) : int
+    protected function getSlowThreshold(TestCase $test): int
     {
         $ann = $test->getAnnotations();
 

--- a/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
+++ b/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
@@ -3,12 +3,7 @@ declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener;
 
-use PHPUnit\Framework\AssertionFailedError;
-use PHPUnit\Framework\TestSuite;
-use PHPUnit\Framework\Test;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\TestListener;
-use PHPUnit\Framework\Warning;
+use PHPUnit\Framework\{AssertionFailedError, TestSuite, Test, TestCase, TestListener, Warning};
 
 /**
  * A PHPUnit TestListener that exposes your slowest running tests by outputting

--- a/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
+++ b/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
@@ -16,8 +16,6 @@ class SpeedTrapListener implements TestListener
      *
      * Increments as more suites are run, then decremented as they finish. All
      * suites have been run when returns to 0.
-     *
-     * @var int
      */
     protected $suites = 0;
 
@@ -38,18 +36,11 @@ class SpeedTrapListener implements TestListener
 
     /**
      * Collection of slow tests.
-     * Keys are labels describing the test (string)
-     * Values are total execution time of given test (int)
-     *
-     * @var array
+     * Keys (string) => Printable label describing the test
+     * Values (int) => Test execution time, in milliseconds
      */
     protected $slow = [];
 
-    /**
-     * Construct a new instance.
-     *
-     * @param array $options
-     */
     public function __construct(array $options = [])
     {
         $this->loadOptions($options);
@@ -180,8 +171,7 @@ class SpeedTrapListener implements TestListener
      * Whether the given test execution time is considered slow.
      *
      * @param int $time          Test execution time in milliseconds
-     * @param int $slowThreshold Test execution time at which a test should be considered slow (milliseconds)
-     * @return bool
+     * @param int $slowThreshold Test execution time at which a test should be considered slow, in milliseconds
      */
     protected function isSlow(int $time, int $slowThreshold): bool
     {
@@ -190,9 +180,6 @@ class SpeedTrapListener implements TestListener
 
     /**
      * Stores a test as slow.
-     *
-     * @param TestCase $test
-     * @param int      $time Test execution time in milliseconds
      */
     protected function addSlowTest(TestCase $test, int $time)
     {
@@ -203,8 +190,6 @@ class SpeedTrapListener implements TestListener
 
     /**
      * Whether at least one test has been considered slow.
-     *
-     * @return bool
      */
     protected function hasSlowTests(): bool
     {
@@ -213,9 +198,6 @@ class SpeedTrapListener implements TestListener
 
     /**
      * Convert PHPUnit's reported test time (microseconds) to milliseconds.
-     *
-     * @param float $time
-     * @return int
      */
     protected function toMilliseconds(float $time): int
     {
@@ -224,9 +206,6 @@ class SpeedTrapListener implements TestListener
 
     /**
      * Label describing a test.
-     *
-     * @param TestCase $test
-     * @return string
      */
     protected function makeLabel(TestCase $test): string
     {
@@ -235,8 +214,6 @@ class SpeedTrapListener implements TestListener
 
     /**
      * Calculate number of tests to include in slowness report.
-     *
-     * @return int
      */
     protected function getReportLength(): int
     {
@@ -246,8 +223,6 @@ class SpeedTrapListener implements TestListener
     /**
      * Calculate number of slow tests to be hidden from the slowness report
      * due to list length.
-     *
-     * @return int
      */
     protected function getHiddenCount(): int
     {
@@ -298,8 +273,6 @@ class SpeedTrapListener implements TestListener
 
     /**
      * Populate options into class internals.
-     *
-     * @param array $options
      */
     protected function loadOptions(array $options)
     {
@@ -319,9 +292,6 @@ class SpeedTrapListener implements TestListener
      * \@slowThreshold 5000
      * public function testLongRunningProcess() {}
      * </code>
-     *
-     * @param TestCase $test
-     * @return int
      */
     protected function getSlowThreshold(TestCase $test): int
     {

--- a/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
+++ b/src/JohnKary/PHPUnit/Listener/SpeedTrapListener.php
@@ -47,14 +47,14 @@ class SpeedTrapListener implements TestListener
      *
      * @var array
      */
-    protected $slow = array();
+    protected $slow = [];
 
     /**
      * Construct a new instance.
      *
      * @param array $options
      */
-    public function __construct(array $options = array())
+    public function __construct(array $options = [])
     {
         $this->loadOptions($options);
     }

--- a/src/JohnKary/PHPUnit/Listener/Tests/ExceptionalTest.php
+++ b/src/JohnKary/PHPUnit/Listener/Tests/ExceptionalTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener\Tests;
 

--- a/src/JohnKary/PHPUnit/Listener/Tests/SomeSlowTest.php
+++ b/src/JohnKary/PHPUnit/Listener/Tests/SomeSlowTest.php
@@ -43,11 +43,11 @@ class SomeSlowTest extends TestCase
     }
     public function provideTime()
     {
-        return array(
-            'Rock' => array(800),
-            'Chalk' => array(700),
-            'Jayhawk' => array(600),
-        );
+        return [
+            'Rock' => [800],
+            'Chalk' => [700],
+            'Jayhawk' => [600],
+        ];
     }
 
     /**

--- a/src/JohnKary/PHPUnit/Listener/Tests/SomeSlowTest.php
+++ b/src/JohnKary/PHPUnit/Listener/Tests/SomeSlowTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener\Tests;
 
@@ -35,7 +36,7 @@ class SomeSlowTest extends TestCase
     /**
      * @dataProvider provideTime
      */
-    public function testWithDataProvider($time)
+    public function testWithDataProvider(int $time)
     {
         $this->extendTime($time);
 
@@ -79,7 +80,7 @@ class SomeSlowTest extends TestCase
     /**
      * @param int $ms Number of additional microseconds to execute code
      */
-    private function extendTime($ms)
+    private function extendTime(int $ms)
     {
         usleep($ms * 1000);
     }


### PR DESCRIPTION
This PR adds new features available in PHP 7.0, the new minimum supported PHP in SpeedTrapListener:

* Enforce [strict_types and scalar type declarations](https://wiki.php.net/rfc/scalar_type_hints_v5) in listener functions (Backward compatibility break documented in UPGRADE.md.)
* [Return type declarations](http://php.net/manual/en/functions.returning-values.php#functions.returning-values.type-declaration) (Backward compatibility break documented in UPGRADE.md.)
* [Null coalesce operator](https://wiki.php.net/rfc/isset_ternary) where appropriate
* [Grouped `use` statements](https://wiki.php.net/rfc/group_use_declarations)

Thanks to @TomasVotruba for his work to inspire adding these features!

Are there any other places in the codebase that benefit from PHP 7 features?