### PR TITLE
Make compatible with phpunit 7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,11 @@ language: php
 sudo: false
 
 php:
-  - 7.0
   - 7.1
   - nightly
 
 env:
-  - PHPUNIT=6.0.*
+  - PHPUNIT=7.*
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 php:
   - 7.1
+  - 7.2
   - nightly
 
 env:

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
-        "phpunit/phpunit": "^6.0"
+        "php": ">=7.1",
+        "phpunit/phpunit": "^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -3,14 +3,18 @@ declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener;
 
-use PHPUnit\Framework\{AssertionFailedError, TestSuite, Test, TestCase, BaseTestListener, Warning};
+use PHPUnit\Framework\{
+    TestListener, TestListenerDefaultImplementation, TestSuite, Test, TestCase
+};
 
 /**
  * A PHPUnit TestListener that exposes your slowest running tests by outputting
  * results directly to the console.
  */
-class SpeedTrapListener extends BaseTestListener
+class SpeedTrapListener implements TestListener
 {
+    use TestListenerDefaultImplementation;
+
     /**
      * Internal tracking for test suites.
      *
@@ -52,7 +56,7 @@ class SpeedTrapListener extends BaseTestListener
      * @param Test  $test
      * @param float $time
      */
-    public function endTest(Test $test, $time)
+    public function endTest(Test $test, float $time): void
     {
         if (!$test instanceof TestCase) return;
 
@@ -69,7 +73,7 @@ class SpeedTrapListener extends BaseTestListener
      *
      * @param TestSuite $suite
      */
-    public function startTestSuite(TestSuite $suite)
+    public function startTestSuite(TestSuite $suite): void
     {
         $this->suites++;
     }
@@ -79,7 +83,7 @@ class SpeedTrapListener extends BaseTestListener
      *
      * @param TestSuite $suite
      */
-    public function endTestSuite(TestSuite $suite)
+    public function endTestSuite(TestSuite $suite): void
     {
         $this->suites--;
 

--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -3,9 +3,7 @@ declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener;
 
-use PHPUnit\Framework\{
-    TestListener, TestListenerDefaultImplementation, TestSuite, Test, TestCase
-};
+use PHPUnit\Framework\{TestListener, TestListenerDefaultImplementation, TestSuite, Test, TestCase};
 
 /**
  * A PHPUnit TestListener that exposes your slowest running tests by outputting


### PR DESCRIPTION
 * Drop compatibility with php 7.0 as phpunit 7 requires 7.1 minimum
 * Update listener with new interface signature
 * Reimplement not to use BaseTestListener from phpunit/framework (not there anymore) 

Since this is a BC break, a release with this code will need tagging as 3.0.