### PR TITLE
Remove invalid phpunit configuration attributes

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,6 @@
     convertWarningsToExceptions = "true"
     processIsolation            = "false"
     stopOnFailure               = "false"
-    syntaxCheck                 = "false"
     bootstrap                   = "vendor/autoload.php">
 
     <testsuites>


### PR DESCRIPTION
Remove the warning:
´´´
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 14:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.
```
You can see it even on travis, for example in https://travis-ci.org/johnkary/phpunit-speedtrap/jobs/401361722 .