### PR TITLE
Improve readability of results

### DIFF
--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -183,9 +183,14 @@ class SpeedTrapListener implements TestListener
         for ($i = 1; $i <= $length; ++$i) {
             $label = key($slowTests);
             $time = array_shift($slowTests);
+            $seconds = $time/1000;
 
-            echo sprintf(" %s. %sms to run %s\n", $i, $time, $label);
+            echo sprintf(" %s - %ss to run %s\n", $i, $seconds, $this->yellow($label));
         }
+    }
+
+    protected function yellow($string) {
+        return "\e[1;33m $string\033[0m";
     }
 
     /**
@@ -194,7 +199,7 @@ class SpeedTrapListener implements TestListener
     protected function renderFooter()
     {
         if ($hidden = $this->getHiddenCount()) {
-            echo sprintf("...and there %s %s more above your threshold hidden from view", $hidden == 1 ? 'is' : 'are', $hidden);
+            echo sprintf("and there %s %s more above your threshold hidden from view.", $hidden == 1 ? 'is' : 'are', $hidden);
         }
     }
 

--- a/tests/SomeSlowTest.php
+++ b/tests/SomeSlowTest.php
@@ -14,7 +14,7 @@ class SomeSlowTest extends TestCase
 
     public function testSlowTests()
     {
-        $this->extendTime(300);
+        $this->extendTime(1300);
 
         $this->assertTrue(true);
     }


### PR DESCRIPTION
This PR should fix the #36 and improve readability with other subtle improvements:

 - show time in seconds instead of milliseconds
 - colorize class name to make it more readable
 - avoid dots at the start of the line to avoid confusion with the test results' report

![screen shot 2018-07-13 at 16 17 26](https://user-images.githubusercontent.com/5879/42696649-202eeb78-86b9-11e8-9a6b-3589ac4fb9e6.png)
