### PR TITLE
Fix: Do not reuse variable

### DIFF
--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -58,11 +58,11 @@ class SpeedTrapListener implements TestListener
     {
         if (!$test instanceof TestCase) return;
 
-        $time = $this->toMilliseconds($time);
+        $timeInMilliseconds = $this->toMilliseconds($time);
         $threshold = $this->getSlowThreshold($test);
 
-        if ($this->isSlow($time, $threshold)) {
-            $this->addSlowTest($test, $time);
+        if ($this->isSlow($timeInMilliseconds, $threshold)) {
+            $this->addSlowTest($test, $timeInMilliseconds);
         }
     }
 


### PR DESCRIPTION
This PR

* [x] introduces a new local variable to avoid re-assigning a method parameter a new value