### PR TITLE
Improve slow tests warning wording

### DIFF
--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -169,7 +169,7 @@ class SpeedTrapListener implements TestListener
      */
     protected function renderHeader()
     {
-        echo sprintf("\n\nYou should really fix these slow tests (>%sms)...\n", $this->slowThreshold);
+        echo sprintf("\n\nYou should really speed up these slow tests (>%sms)...\n", $this->slowThreshold);
     }
 
     /**


### PR DESCRIPTION
"Fix" could imply the test is failing while it could be passing and being slow at the same time.