### PR TITLE
Adds the option to fail on the first slow test rather than continuing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ SpeedTrap has two configurable parameters:
 
 * **slowThreshold** - Number of milliseconds a test takes to execute before being considered "slow" (Default: 500ms)
 * **reportLength** - Number of slow tests included in the report (Default: 10 tests)
+* **failOnFirst** - Fail out on the first slow test detected rather than continuing to run (Default: false)
 
 These configuration parameters are set in `phpunit.xml` when adding the listener:
 
@@ -54,6 +55,9 @@ These configuration parameters are set in `phpunit.xml` when adding the listener
                     </element>
                     <element key="reportLength">
                         <integer>5</integer>
+                    </element>
+                    <element key="failOnFirst">
+                        <boolean>true</boolean>
                     </element>
                 </array>
             </arguments>

--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -3,7 +3,6 @@ declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener;
 
-use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\{TestListener, TestListenerDefaultImplementation, TestSuite, Test, TestCase};
 
 /**


### PR DESCRIPTION
Justification:

I'm working on an application with > 3700 tests. The last time I tried to run the suite locally, I Ctrl-C'd after 6 hours. The test progress had reached a whopping 35%. It's a known problem that "some number of tests" (read: hundreds) exceed 5min run time but it's obviously extremely painful for the dev team to identify which ones need attention.

I would really love to add Speed Trap to this project but unfortunately there's just no way to let the entire suite run in full.

What changes:

This change allows for a flag to stop the suite upon the first test that exceeds the configured Slow Threshold.