### PR TITLE
Travis build matrix tests most recent releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ matrix:
     env: PHPUNIT=8.*
   - php: 7.1
     env: PHPUNIT=dev-master MIN_STABILITY=dev
+  - php: 7.2
+    env: PHPUNIT=dev-master MIN_STABILITY=dev
   allow_failures:
   - php: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 
 env:


### PR DESCRIPTION
SpeedTrap's build matrix continues to run on Travis CI. A few builds on our master branch are currently broken because of various upstream changes in PHP core and PHPUnit:

* 2019-11-25 PHPUnit dev-master branch moved from targeting PHPUnit 8.* to 9.* via commit [`phpunit/phpunit#7c57137`](https://github.com/sebastianbergmann/phpunit/commit/7c57137323faa15131fc0e70c24fb84f88101609)
* 2019-11-28 [PHP 7.4.0](https://www.php.net/releases/7_4_0.php) stable was released

This PR fixes the following issues in the SpeedTrap build matrix:

* 0bb6fdd -- PHPUnit 9.0-dev increased the minimum required PHP version from PHP 7.2 to 7.3. SpeedTrap will no longer test PHP 7.2 against PHPUnit dev-master.
* e1bf5e3 -- SpeedTrap now tested against PHP 7.4 latest stable release

## Things that may need attention

PHPUnit 9.0.0 stable is targeting release in February 2020. Do we need to add PHPUNIT=9.* to the build matrix yet?