### PR TITLE
Add support for PHPUnit 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
 env:
   - PHPUNIT=7.*
   - PHPUNIT=8.*
+  - PHPUNIT=9.*
   - PHPUNIT=dev-master MIN_STABILITY=dev
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "phpunit/phpunit": "^7.0 || ^8.0"
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
PHPUnit 9.0.0 was just released but I can't upgrade because of the lack of a compatibility declaration here.
I've ran the test suite against 8 and 9 and it appears to run the same on my local system