### PR TITLE
Replace the removed getAnnotations() method with the utility

### DIFF
--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace JohnKary\PHPUnit\Listener;
 
+use PHPUnit\Util\Test as TestUtil;
 use PHPUnit\Framework\{TestListener, TestListenerDefaultImplementation, TestSuite, Test, TestCase};
 
 /**
@@ -240,7 +241,7 @@ class SpeedTrapListener implements TestListener
      */
     protected function getSlowThreshold(TestCase $test): int
     {
-        $ann = $test->getAnnotations();
+        $ann = TestUtil::parseTestMethodAnnotations(get_class($test), $test->getName());
 
         return isset($ann['method']['slowThreshold'][0]) ? (int) $ann['method']['slowThreshold'][0] : $this->slowThreshold;
     }


### PR DESCRIPTION
PHPUnit 9.5.0 dropped the `getAnnotations()` method, so this PR follows suit and uses the util directly instead.
https://github.com/sebastianbergmann/phpunit/commit/68582043e149039cfa3596b42ed35753dcf54fb2

`Call to undefined method getAnnotations()`