### PR TITLE
Replace double points with two double points for copy and past

### DIFF
--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -155,7 +155,7 @@ class SpeedTrapListener implements TestListener
      */
     protected function makeLabel(TestCase $test): string
     {
-        return sprintf('%s:%s', get_class($test), $test->getName());
+        return sprintf('%s::%s', get_class($test), $test->getName());
     }
 
     /**


### PR DESCRIPTION
To enable copy and past of a slow test into the phpunit filter argument, a double point is missing.

![image](https://user-images.githubusercontent.com/14017436/107212913-f274fa80-6a07-11eb-8c7b-d0e9e28f71e7.png)
