### PR TITLE
Reformat slow test case output for compatibility with PHPUnit --filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Many factors affect test execution time. A test not properly isolated from varia
 
 SpeedTrap helps **identify slow tests** but cannot explain **why** those tests are slow. For that consider using [Blackfire.io](https://blackfire.io) to profile the test suite, or another PHPUnit listener [PHPUnit\_Listener\_XHProf](https://github.com/sebastianbergmann/phpunit-testlistener-xhprof), to specifically identify slow code.
 
-![Screenshot of terminal using SpeedTrap](http://i.imgur.com/Zr34giR.png)
+![Screenshot of terminal using SpeedTrap](https://i.imgur.com/xSpWL4Z.png)
 
 ## Installation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,29 @@
+UPGRADE FROM 3.x to 4.0
+=======================
+
+### Slowness report changes formatting of slow class names
+
+Prior to 4.0 the slowness report displayed the qualified class name in a
+human-readable format as normally seen in code:
+
+    1. 800ms to run JohnKary\PHPUnit\Listener\Tests\SomeSlowTest:testWithDataProvider with data set "Rock"
+
+After 4.0 the slowness report displays class names in a format ready to be
+used with PHPUnit's [--filter option](https://phpunit.readthedocs.io/en/9.5/textui.html?highlight=filter)
+by adding slashes to the namespace delimiter and adding a colon between the
+class and method name:
+
+    1. 800ms to run JohnKary\\PHPUnit\\Listener\\Tests\\SomeSlowTest::testWithDataProvider with data set "Rock"
+
+An individual slow test case can now be re-run by copying and pasting the output
+into a new command:
+
+    vendor/bin/phpunit --filter 'JohnKary\\PHPUnit\\Listener\\Tests\\SomeSlowTest::testWithDataProvider with data set "Rock"'
+
+Note that PHPUnit uses single quotes for the `--filter` option value. See the
+[--filter option documentation](https://phpunit.readthedocs.io/en/9.5/textui.html?highlight=filter)
+for all supported matching patterns.
+
 UPGRADE FROM 2.x to 3.0
 =======================
 

--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -151,11 +151,14 @@ class SpeedTrapListener implements TestListener
     }
 
     /**
-     * Label describing a test.
+     * Label describing a slow test case. Formatted to support copy/paste with
+     * PHPUnit's --filter CLI option:
+     *
+     *     vendor/bin/phpunit --filter 'JohnKary\\PHPUnit\\Listener\\Tests\\SomeSlowTest::testWithDataProvider with data set "Rock"'
      */
     protected function makeLabel(TestCase $test): string
     {
-        return sprintf('%s::%s', get_class($test), $test->getName());
+        return sprintf('%s::%s', addslashes(get_class($test)), $test->getName());
     }
 
     /**


### PR DESCRIPTION
This builds on #80. Thanks @PascalThesing for the idea!

![Screenshot of new report format](https://i.imgur.com/xSpWL4Z.png)

## Overview

Prior to this PR the slowness report displayed the qualified class name in a human-readable format as normally seen in code:

    1. 800ms to run JohnKary\PHPUnit\Listener\Tests\SomeSlowTest:testWithDataProvider with data set "Rock"

This PR proposes the slowness report display class names in a format compatible with PHPUnit's [--filter option](https://phpunit.readthedocs.io/en/9.5/textui.html?highlight=filter). The class name now adds slashes to the namespace delimiter and adds another colon between the class and method name:

    1. 800ms to run JohnKary\\PHPUnit\\Listener\\Tests\\SomeSlowTest::testWithDataProvider with data set "Rock"

An individual slow test case can now be re-run by copying and pasting the output into a new PHPUnit command to run just that test case:

    vendor/bin/phpunit --filter 'JohnKary\\PHPUnit\\Listener\\Tests\\SomeSlowTest::testWithDataProvider with data set "Rock"'

Note that PHPUnit uses single quotes for the `--filter` option value. See the [--filter option documentation](https://phpunit.readthedocs.io/en/9.5/textui.html?highlight=filter) for all supported matching patterns.

### Feedback Requested

A program's text output and CLI return codes are part of its public API, even though most developers don't think about it. Any downstream program consuming the output is relying on an undocumented API. Changing the text output is a breaking change for any integration that programmatically reads the slowness report. This change will be wrapped and documented into the next major version v4.0 to guard against potential impacts.

If you are programmatically consuming the slowness output, please describe your use case to help maintainers understand how it is being used. Please comment if and how this change could impact you.

Are there other concerns about changing the display format?

Are there other formatting changes we should consider for the next major release?