### PR TITLE
New option stopOnSlow halts execution upon first slow test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ https://github.com/johnkary/phpunit-speedtrap/compare/v3.3.0...v4.0.0
 
 ## 4.0 (xxxx-xx-xx)
 
-
+* New option `stopOnSlow` stops execution upon first slow test. Default: false.
 
 ## 3.3.0 (2020-12-18)
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ SpeedTrap also supports these parameters:
 
 * **slowThreshold** - Number of milliseconds when a test is considered "slow" (Default: 500ms)
 * **reportLength** - Number of slow tests included in the report (Default: 10 tests)
+* **stopOnSlow** - Stop execution upon first slow test (Default: false)
 
 Each parameter is set in `phpunit.xml`:
 
@@ -54,6 +55,9 @@ Each parameter is set in `phpunit.xml`:
                     </element>
                     <element key="reportLength">
                         <integer>10</integer>
+                    </element>
+                    <element key="stopOnSlow">
+                        <boolean>false</boolean>
                     </element>
                 </array>
             </arguments>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,6 +30,9 @@
                     <element key="reportLength">
                         <integer>5</integer>
                     </element>
+                    <element key="stopOnSlow">
+                        <boolean>false</boolean>
+                    </element>
                 </array>
             </arguments>
         </listener>

--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -49,6 +49,14 @@ class SpeedTrapListener implements TestListener
     protected $reportLength;
 
     /**
+     * Whether the test runner should halt running additional tests after
+     * finding a slow test.
+     *
+     * @var bool
+     */
+    protected $stopOnSlow;
+
+    /**
      * Collection of slow tests.
      * Keys (string) => Printable label describing the test
      * Values (int) => Test execution time, in milliseconds
@@ -132,6 +140,10 @@ class SpeedTrapListener implements TestListener
         $label = $this->makeLabel($test);
 
         $this->slow[$label] = $time;
+
+        if ($this->stopOnSlow) {
+            $test->getTestResultObject()->stop();
+        }
     }
 
     /**
@@ -224,6 +236,7 @@ class SpeedTrapListener implements TestListener
     {
         $this->slowThreshold = $options['slowThreshold'] ?? 500;
         $this->reportLength = $options['reportLength'] ?? 10;
+        $this->stopOnSlow = $options['stopOnSlow'] ?? false;
     }
 
     /**


### PR DESCRIPTION
Alternate implementation for #64. Thanks @PeterDKC for proposing this idea.

Some test suites run for a long time. PHPUnit already supports command-line options for halting execution when different test result types are first encountered. This allows more quickly notifying developers about problems in the test suite.

* --stop-on-error
* --stop-on-failure
* --stop-on-warning
* --stop-on-risky
* --stop-on-skipped
* --stop-on-incomplete

This PR proposes a new SpeedTrap option `stopOnSlow` to stop execution upon the first slow test.

The option is controlled using `phpunit.xml` like other SpeedTrap options:

```xml
<phpunit bootstrap="vendor/autoload.php">
    <!-- ... other suite configuration here ... -->

    <listeners>
        <listener class="JohnKary\PHPUnit\Listener\SpeedTrapListener">
            <arguments>
                <array>
                    ...
                    <element key="stopOnSlow">
                        <boolean>false</boolean>
                    </element>
                </array>
            </arguments>
        </listener>
    </listeners>
</phpunit>
```

### What does it look like when the test suite halts due to a slow test?

The slowness report displays with the single slow test, followed by PHPUnit's normal test runner report.

<img width="758" alt="Screenshot 2021-02-28 11 06 36 png@2x" src="https://user-images.githubusercontent.com/135607/109426814-14cdb880-79b5-11eb-94e5-19d8fa5f7c83.png">