### PR TITLE
Disabling Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ https://github.com/johnkary/phpunit-speedtrap/compare/v3.3.0...v4.0.0
 ## 4.0 (xxxx-xx-xx)
 
 * New option `stopOnSlow` stops execution upon first slow test. Default: false.
+* New annotation option `@slowThreshold 0` disables checks for individual tests.
 
 ## 3.3.0 (2020-12-18)
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ class SomeTestCase extends PHPUnit\Framework\TestCase
 }
 ```
 
+Setting `@slowThreshold` to `0` will disable threshold reports for that test.
+
 ## Disable slowness profiling using an environment variable
 
 SpeedTrapListener profiles for slow tests when enabled in phpunit.xml. But using an environment variable named `PHPUNIT_SPEEDTRAP` can enable or disable the listener.

--- a/src/SpeedTrapListener.php
+++ b/src/SpeedTrapListener.php
@@ -129,7 +129,7 @@ class SpeedTrapListener implements TestListener
      */
     protected function isSlow(int $time, int $slowThreshold): bool
     {
-        return $time >= $slowThreshold;
+        return $time && $time >= $slowThreshold;
     }
 
     /**

--- a/tests/SomeSlowTest.php
+++ b/tests/SomeSlowTest.php
@@ -66,12 +66,25 @@ class SomeSlowTest extends TestCase
 
     /**
      * This test's runtime would normally be over the suite's threshold, but
-     * this annotation sets a higher threshold, causing it to be not be
-     * considered slow and not reported on in the test output.
+     * this annotation sets a higher threshold causing it not to be
+     * considered slow and not reported in the test output.
      *
      * @slowThreshold 50000
      */
     public function testCanSetHigherSlowThreshold()
+    {
+        $this->extendTime(600);
+        $this->assertTrue(true);
+    }
+
+    /**
+     * This test's runtime would normally be over the suite's threshold, but
+     * this annotation disables threshold checks causing it not to be
+     * considered slow and not reported in the test output.
+     *
+     * @slowThreshold 0
+     */
+    public function testCanDisableSlowThreshold()
     {
         $this->extendTime(600);
         $this->assertTrue(true);


### PR DESCRIPTION
This PR adds the option to disable individual tests by setting the `@slowThreshold` annotation to `0`.

This was referenced in a few other issues and something I would use a lot. I think this is the cleanest approach but let me know if you would prefer an alternate annotation, like `@disableThreshold`.