### PR TITLE
Improve readability of results (rework)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Many factors affect test execution time. A test not properly isolated from varia
 
 SpeedTrap helps **identify slow tests** but cannot explain **why** those tests are slow. Consider using [Blackfire.io](https://blackfire.io) to profile the test suite to specifically identify slow code.
 
-![Screenshot of terminal using SpeedTrap](https://i.imgur.com/xSpWL4Z.png)
+![Screenshot of terminal using SpeedTrap](https://user-images.githubusercontent.com/135607/196077193-ba9e5f95-91ef-4655-88a5-93bb49007a67.png)
 
 ## Installation
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -38,6 +38,14 @@ must extend the new `JohnKary\PHPUnit\Extension\SpeedTrap`. There are various
 method name changes that may affect your custom subclass. See [PR #83](https://github.com/johnkary/phpunit-speedtrap/pull/83)
 for many of the new class has changed.
 
+If you programmatically parse the slowness report text visible when running
+`vendor/bin/phpunit`, there have been some text formatting changes in the output:
+
+* The header text has changed
+* The footer text has changed
+* The slow test output has changed
+* Slowness execution time now displays in seconds instead of milliseconds
+
 UPGRADE FROM 3.x to 4.0
 =======================
 

--- a/src/SpeedTrap.php
+++ b/src/SpeedTrap.php
@@ -195,7 +195,7 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
      */
     protected function renderHeader(): void
     {
-        echo sprintf("\n\nYou should really speed up these slow tests (>%sms)\n", $this->slowThreshold);
+        echo sprintf("\n\nThe following tests were detected as slow (>%sms)\n", $this->slowThreshold);
     }
 
     /**
@@ -221,7 +221,7 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
     protected function renderFooter(): void
     {
         if ($hidden = $this->getHiddenCount()) {
-            printf("and there %s %s more above your threshold hidden from view\n", $hidden == 1 ? 'is' : 'are', $hidden);
+            printf("and %s more slow tests hidden from view\n", $hidden);
         }
     }
 

--- a/src/SpeedTrap.php
+++ b/src/SpeedTrap.php
@@ -195,7 +195,7 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
      */
     protected function renderHeader(): void
     {
-        echo sprintf("\n\nYou should really speed up these slow tests (>%sms)...\n", $this->slowThreshold);
+        echo sprintf("\n\nYou should really speed up these slow tests (>%sms)\n", $this->slowThreshold);
     }
 
     /**
@@ -211,7 +211,7 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
             $time = array_shift($slowTests);
             $seconds = $time / 1000;
 
-            echo sprintf(" %s. %ss to run %s\n", $i, $seconds, $label);
+            echo sprintf(" %s) %ss to run %s\n", $i, $seconds, $label);
         }
     }
 
@@ -221,7 +221,7 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
     protected function renderFooter(): void
     {
         if ($hidden = $this->getHiddenCount()) {
-            printf("...and there %s %s more above your threshold hidden from view\n", $hidden == 1 ? 'is' : 'are', $hidden);
+            printf("and there %s %s more above your threshold hidden from view\n", $hidden == 1 ? 'is' : 'are', $hidden);
         }
     }
 

--- a/src/SpeedTrap.php
+++ b/src/SpeedTrap.php
@@ -209,8 +209,9 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
         for ($i = 1; $i <= $length; ++$i) {
             $label = key($slowTests);
             $time = array_shift($slowTests);
+            $seconds = $time / 1000;
 
-            echo sprintf(" %s. %sms to run %s\n", $i, $time, $label);
+            echo sprintf(" %s. %ss to run %s\n", $i, $seconds, $label);
         }
     }
 

--- a/src/SpeedTrap.php
+++ b/src/SpeedTrap.php
@@ -211,7 +211,7 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
             $time = array_shift($slowTests);
             $seconds = $time / 1000;
 
-            echo sprintf(" %s) %ss to run %s\n", $i, $seconds, $label);
+            echo sprintf(" %s) %.3fs to run %s\n", $i, $seconds, $label);
         }
     }
 

--- a/tests/SomeSlowTest.php
+++ b/tests/SomeSlowTest.php
@@ -33,6 +33,13 @@ class SomeSlowTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function testSlowTestsOverOneSecond()
+    {
+        $this->extendTime(1300);
+
+        $this->assertTrue(true);
+    }
+
     /**
      * @dataProvider provideTime
      */


### PR DESCRIPTION
This PR builds on the work by @fain182 in #47. The core Listener was replaced by the Hook extension system, making #47 obsolete.

Before this PR, the "header" output contained text "You should really speed up these slow tests". This PR replaces it with more neutral language, "The following tests were detected as slow".

Before this PR, the output displayed slowness time in milliseconds. Feature suggestions in #36 reported milliseconds as hard to read. This PR changes the slowness report to display slow times in seconds like `12.543s` instead of milliseconds like `12543ms`.

Before this PR, the "footer" output contained text "...and there is 2 more above your threshold hidden from view". This PR replaces it with more simple language and less punctuation, "and 2 more slow tests hidden from view".

Closes #47
Closes #36

### Screenshot

![phpunit-speedtrap-v5](https://user-images.githubusercontent.com/135607/196077193-ba9e5f95-91ef-4655-88a5-93bb49007a67.png)