### PR TITLE
Fix: Ignore `phpunit` result cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /phpunit.xml
 /vendor
+/.phpunit.result.cache
 /composer.lock


### PR DESCRIPTION
This pull request

- [x] ignores `.phpunit.result.cache`

💁‍♂️ After checking out the repository, installing dependencies, and running tests, we are left with untracked files.