### PR TITLE
Enhancement: Update extension to use event system of `phpunit/phpunit:10.0.0`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -18,33 +18,9 @@ jobs:
       fail-fast: false
 
       matrix:
-        include:
-          - php-version: "7.2"
-            phpunit-version: "8.*"
-
-          - php-version: "7.3"
-            phpunit-version: "8.*"
-
-          - php-version: "7.3"
-            phpunit-version: "9.*"
-
-          - php-version: "7.4"
-            phpunit-version: "8.*"
-
-          - php-version: "7.4"
-            phpunit-version: "9.*"
-
-          - php-version: "8.0"
-            phpunit-version: "8.*"
-
-          - php-version: "8.0"
-            phpunit-version: "9.*"
-
-          - php-version: "8.1"
-            phpunit-version: "8.*"
-
-          - php-version: "8.1"
-            phpunit-version: "9.*"
+        php-version:
+          - "8.1"
+          - "8.2"
 
     steps:
       - name: "Checkout"
@@ -69,8 +45,8 @@ jobs:
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.phpunit-version }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-"
 
-      - name: "Require phpunit/phpunit ${{ matrix.phpunit-version }}"
-        run: "composer require phpunit/phpunit:${{ matrix.phpunit-version }}"
+      - name: "Install dependencies with composer"
+        run: "composer install --no-interaction --no-progress"
 
       - name: "Run tests with phpunit/phpunit"
         run: "vendor/bin/phpunit"

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Enable with all defaults by adding the following code to your project's `phpunit
 <phpunit bootstrap="vendor/autoload.php">
 ...
     <extensions>
-        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap" />
+        <bootstrap class="JohnKary\PHPUnit\Extension\SpeedTrapExtension" />
     </extensions>
 </phpunit>
 ```
@@ -46,18 +46,10 @@ Each parameter is set in `phpunit.xml`:
     <!-- ... other suite configuration here ... -->
 
     <extensions>
-        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap">
-            <arguments>
-                <array>
-                    <element key="slowThreshold">
-                        <integer>500</integer>
-                    </element>
-                    <element key="reportLength">
-                        <integer>10</integer>
-                    </element>
-                </array>
-            </arguments>
-        </extension>
+        <bootstrap class="JohnKary\PHPUnit\Extension\SpeedTrapExtension">
+            <parameter name="slowThreshold" value="500" />
+            <parameter name="reportLength" value="10" />
+        </bootstrap>
     </extensions>
 </phpunit>
 ```
@@ -132,7 +124,7 @@ Step 1) Enable SpeedTrap in phpunit.xml. The slowness report will output during 
 <phpunit bootstrap="vendor/autoload.php">
 ...
     <extensions>
-        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap" />
+        <bootstrap class="JohnKary\PHPUnit\Extension\SpeedTrapExtension" />
     </extensions>
 </phpunit>
 ```
@@ -165,7 +157,7 @@ Step 1) Setup phpunit.xml to enable SpeedTrap, but disable slowness profiling by
     </php>
 
     <extensions>
-        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap" />
+        <bootstrap class="JohnKary\PHPUnit\Extension\SpeedTrapExtension" />
     </extensions>
 </phpunit>
 ```
@@ -192,7 +184,7 @@ The easiest way to set environment variables for the script `simple-phpunit` is 
     </php>
 
     <extensions>
-        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap" />
+        <bootstrap class="JohnKary\PHPUnit\Extension\SpeedTrapExtension" />
     </extensions>
 </phpunit>
 ```

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "phpunit/phpunit": "^8.0 || ^9.0"
+        "php": "^8.1",
+        "phpunit/phpunit": "^10.0.0"
     },
     "extra": {
         "branch-alias": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,9 +2,10 @@
 <!-- https://phpunit.readthedocs.io/en/stable/configuration.html -->
 <phpunit
     xmlns:xsi                     = "http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation = "https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation = "https://schema.phpunit.de/10.0/phpunit.xsd"
     colors                        = "true"
-    bootstrap                     = "vendor/autoload.php">
+    bootstrap                     = "vendor/autoload.php"
+>
 
     <coverage>
         <include>
@@ -19,18 +20,10 @@
     </testsuites>
 
     <extensions>
-        <extension class="JohnKary\PHPUnit\Extension\SpeedTrap">
-            <arguments>
-                <array>
-                    <element key="slowThreshold">
-                        <integer>500</integer>
-                    </element>
-                    <element key="reportLength">
-                        <integer>5</integer>
-                    </element>
-                </array>
-            </arguments>
-        </extension>
+        <bootstrap class="JohnKary\PHPUnit\Extension\SpeedTrapExtension">
+            <parameter name="slowThreshold" value="500"/>
+            <parameter name="reportLength" value="5"/>
+        </bootstrap>
     </extensions>
 
 </phpunit>

--- a/src/PreparedTest.php
+++ b/src/PreparedTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JohnKary\PHPUnit\Extension;
+
+use PHPUnit\Event;
+
+final class PreparedTest
+{
+    public function __construct(
+        private readonly Event\Code\Test $test,
+        private readonly Event\Telemetry\HRTime $start
+    ) {
+    }
+
+    public function test(): Event\Code\Test
+    {
+        return $this->test;
+    }
+
+    public function start(): Event\Telemetry\HRTime
+    {
+        return $this->start;
+    }
+}

--- a/src/RecordThatTestHasBeenPrepared.php
+++ b/src/RecordThatTestHasBeenPrepared.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JohnKary\PHPUnit\Extension;
+
+use PHPUnit\Event;
+
+final class RecordThatTestHasBeenPrepared implements Event\Test\PreparedSubscriber
+{
+    public function __construct(private readonly SpeedTrap $speedTrap)
+    {
+    }
+
+    public function notify(Event\Test\Prepared $event): void
+    {
+        $this->speedTrap->recordThatTestHasBeenPrepared(
+            $event->test(),
+            $event->telemetryInfo()->time(),
+        );
+    }
+}

--- a/src/RecordThatTestHasPassed.php
+++ b/src/RecordThatTestHasPassed.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JohnKary\PHPUnit\Extension;
+
+use PHPUnit\Event;
+
+final class RecordThatTestHasPassed implements Event\Test\PassedSubscriber
+{
+    public function __construct(private readonly SpeedTrap $speedTrap)
+    {
+    }
+
+    public function notify(Event\Test\Passed $event): void
+    {
+        $this->speedTrap->recordThatTestHasPassed(
+            $event->test(),
+            $event->telemetryInfo()->time(),
+        );
+    }
+}

--- a/src/ShowSlowTests.php
+++ b/src/ShowSlowTests.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JohnKary\PHPUnit\Extension;
+
+use PHPUnit\Event;
+
+final class ShowSlowTests implements Event\TestRunner\ExecutionFinishedSubscriber
+{
+    public function __construct(private readonly SpeedTrap $speedTrap)
+    {
+    }
+
+    public function notify(Event\TestRunner\ExecutionFinished $event): void
+    {
+        $this->speedTrap->showSlowTests();
+    }
+}

--- a/src/SpeedTrapExtension.php
+++ b/src/SpeedTrapExtension.php
@@ -1,0 +1,43 @@
+<?php
+declare(strict_types=1);
+
+namespace JohnKary\PHPUnit\Extension;
+
+use PHPUnit\Runner;
+use PHPUnit\TextUI;
+
+final class SpeedTrapExtension implements Runner\Extension\Extension
+{
+    public function bootstrap(
+        TextUI\Configuration\Configuration $configuration,
+        Runner\Extension\Facade $facade,
+        Runner\Extension\ParameterCollection $parameters
+    ): void {
+        if (getenv('PHPUNIT_SPEEDTRAP') === 'disabled') {
+            return;
+        }
+
+        $slowThreshold = 500;
+
+        if ($parameters->has('slowThreshold')) {
+            $slowThreshold = (int) $parameters->get('slowThreshold');
+        }
+
+        $reportLength = 10;
+
+        if ($parameters->has('reportLength')) {
+            $reportLength = (int) $parameters->get('reportLength');
+        }
+
+        $speedTrap = new SpeedTrap(
+            $slowThreshold,
+            $reportLength
+        );
+
+        $facade->registerSubscribers(
+            new RecordThatTestHasBeenPrepared($speedTrap),
+            new RecordThatTestHasPassed($speedTrap),
+            new ShowSlowTests($speedTrap),
+        );
+    }
+}

--- a/tests/SomeSlowTest.php
+++ b/tests/SomeSlowTest.php
@@ -49,7 +49,7 @@ class SomeSlowTest extends TestCase
 
         $this->assertTrue(true);
     }
-    public function provideTime()
+    public static function provideTime()
     {
         return [
             'Rock' => [800],


### PR DESCRIPTION
This pull request

- [x] updates the extension to use the new event system of `phpunit/phpunit:10.0.0`, 2023

Follows #83.
Related to https://github.com/sebastianbergmann/phpunit/issues/4676.

💁‍♂️ I will talk about [Extending PHPUnit with its New Event System](https://phpconference.com/web-security-3/extending-phpunit-with-its-new-event-system/) on October 25, 2022, at the [International PHP Conference 2022 (Munich)](https://phpconference.com/muenchen/)

Since this extension is one of the few that I have been using and contributed to, I would like to use this pull request to demonstrate updating an existing extension to the new event system.

You recently updated the extension from the deprecated hooks interface to using the deprecated `TestListener` (see #83). `phpunit/phpunit:10.0.0`, which will be released on February 3, 2023, will remove the deprecated hooks and `TestListener` extension points.

To keep the diff small and understandable, I have tried to make the fewest changes possible.

I understand that there could be more work done, which I am happy to do, but I believe that this would be beyond the scope of this pull request.
