### PR TITLE
Visually align results a bit more

### DIFF
--- a/src/SpeedTrap.php
+++ b/src/SpeedTrap.php
@@ -211,7 +211,7 @@ class SpeedTrap implements AfterSuccessfulTestHook, BeforeFirstTestHook, AfterLa
             $time = array_shift($slowTests);
             $seconds = $time / 1000;
 
-            echo sprintf(" %s) %.3fs to run %s\n", $i, $seconds, $label);
+            echo sprintf("%2s) %6.3fs to run %s\n", $i, $seconds, $label);
         }
     }
 


### PR DESCRIPTION
Always make the test number at least two digits wide, but remove the space before it. For numbers below 10, this makes no difference; for numbers between 10 and 99, it makes the number aligned with the lower numbers; only at 100 and above will the numbers start to become unaligned.

Always make the test duration at least six characters wide in total. The decimal digits stay at 3 as before; subtracting one character for the decimal point itself, that leaves a minimum of two for the “seconds” part, so that test durations up to 99 seconds now stay aligned with each other, and only become unaligned at ≥ 100 seconds.

----

This is motivated by our use of phpunit-speedtrap at Wikimedia, where we set the report length to 50, and (unfortunately) have tests that take over ten seconds. I was quite delighted to discover that you’d already made some improvements in #93; I hope you’ll consider these further small changes.

Example result, with a higher report length and some extra uncommitted tests:

```
PHPUnit 9.5.26 by Sebastian Bergmann and contributors.

.SI................                                               19 / 19 (100%)

The following tests were detected as slow (>500ms)
 1) 12.000s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testLucas with data set #4
 2)  4.000s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testLucas with data set #3
 3)  3.000s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testLucas with data set #2
 4)  2.000s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testLucas with data set #1
 5)  1.300s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testSlowTestsOverOneSecond
 6)  1.000s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testLucas with data set #0
 7)  0.800s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testWithDataProvider with data set "Rock"
 8)  0.700s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testWithDataProvider with data set "Chalk"
 9)  0.600s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testWithDataProvider with data set "Jayhawk"
10)  0.500s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testAnotherSlowTests
11)  0.500s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testLongEndToEndTest
12)  0.010s to run JohnKary\\PHPUnit\\Extension\\Tests\\SomeSlowTest::testCanSetLowerSlowThreshold


Time: 00:27.939, Memory: 6.00 MB
```